### PR TITLE
Initial addition of the header breadcrumb

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -7,5 +7,7 @@ define( 'STRATEGICPLAN_THEME_DIR', trailingslashit( get_stylesheet_directory() )
 // Theme foundation
 include_once STRATEGICPLAN_THEME_DIR . 'includes/config.php';
 include_once STRATEGICPLAN_THEME_DIR . 'includes/meta.php';
+include_once STRATEGICPLAN_THEME_DIR . 'includes/header-functions.php';
+
 
 // Add other includes to this file as needed.

--- a/includes/config.php
+++ b/includes/config.php
@@ -10,3 +10,51 @@ define( 'STRATEGICPLAN_THEME_STATIC_URL', STRATEGICPLAN_THEME_URL . '/static' );
 define( 'STRATEGICPLAN_THEME_CSS_URL', STRATEGICPLAN_THEME_STATIC_URL . '/css' );
 define( 'STRATEGICPLAN_THEME_JS_URL', STRATEGICPLAN_THEME_STATIC_URL . '/js' );
 define( 'STRATEGICPLAN_THEME_IMG_URL', STRATEGICPLAN_THEME_STATIC_URL . '/img' );
+define( 'STRATEGICPLAN_THEME_CUSTOMIZER_PREFIX', 'ucfstrategicplan_' );
+
+
+/**
+ * Defines sections used in the WordPress Customizer.
+ *
+ * @since 1.0.0
+ * @author Cadie Stockman
+ */
+function define_customizer_sections( $wp_customize ) {
+	$wp_customize->add_section(
+		STRATEGICPLAN_THEME_CUSTOMIZER_PREFIX . 'headers',
+		array(
+			'title' => 'Headers'
+		)
+	);
+}
+
+add_action( 'customize_register', __NAMESPACE__ . '\define_customizer_sections' );
+
+
+/**
+ * Defines settings and controls used in the WordPress Customizer.
+ *
+ * @since 1.0.0
+ * @author Cadie Stockman
+ */
+function define_customizer_fields( $wp_customize ) {
+	// Headers
+	$wp_customize->add_setting(
+		'header_breadcrumb_text',
+		array(
+			'default' => ''
+		)
+	);
+
+	$wp_customize->add_control(
+		'header_breadcrumb_text',
+		array(
+			'type'        => 'text',
+			'label'       => 'Header breadcrumb text',
+			'description' => 'Text to display above the page title on all subpages (excluding those using custom header markup). This text links back to the site homepage.',
+			'section'     => STRATEGICPLAN_THEME_CUSTOMIZER_PREFIX . 'headers'
+		)
+	);
+}
+
+add_action( 'customize_register', __NAMESPACE__ . '\define_customizer_fields' );

--- a/includes/header-functions.php
+++ b/includes/header-functions.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Includes functions that handle customization and/or
+ * overrides of headers from the UCF WordPress Theme.
+ **/
+namespace StrategicPlan\Theme\Includes\Header_Functions;
+
+
+/**
+ * Returns markup for a breadcrumb back to the homepage, for use above
+ * page header title+subtitles.
+ *
+ * Copied from Coronavirus-Child-Theme.
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ * @return string
+ */
+function get_breadcrumb() {
+	$retval = '';
+	if ( ! is_front_page() ) {
+		$breadcrumb_text = trim( wptexturize( get_theme_mod( 'header_breadcrumb_text' ) ) );
+
+		if ( $breadcrumb_text ) {
+			ob_start();
+		?>
+			<nav aria-label="Home breadcrumb">
+				<a class="badge badge-primary badge-lg font-size-sm mb-4" href="<?php echo get_home_url(); ?>">
+					<?php echo $breadcrumb_text; ?>
+				</a>
+			</nav>
+		<?php
+			$retval = trim( ob_get_clean() );
+		}
+	}
+	return $retval;
+}

--- a/template-parts/header_content-title_subtitle.php
+++ b/template-parts/header_content-title_subtitle.php
@@ -1,0 +1,36 @@
+<?php
+use StrategicPlan\Theme\Includes as Includes;
+
+$obj              = ucfwp_get_queried_object();
+$title            = ucfwp_get_header_title( $obj );
+$subtitle         = ucfwp_get_header_subtitle( $obj );
+$h1               = ucfwp_get_header_h1_option( $obj );
+$h1_elem          = ucfwp_get_header_h1_elem( $obj );
+$title_elem       = ( $h1 === 'title' ) ? $h1_elem : 'span';
+$subtitle_elem    = ( $h1 === 'subtitle' ) ? $h1_elem : 'p';
+$title_classes    = 'text-inverse display-3 font-condensed text-uppercase text-shadow-soft';
+$subtitle_classes = 'pt-2 text-inverse font-size-lg text-shadow-soft';
+$breadcrumb       = Includes\Header_Functions\get_breadcrumb();
+?>
+
+<?php if ( $title ): ?>
+<div class="header-content-inner align-self-center py-5 pb-sm-4 mt-sm-5">
+	<div class="container">
+		<div class="row">
+			<div class="col-10 col-sm-11 col-md-10 col-lg-7 col-xl-6">
+				<?php echo $breadcrumb; ?>
+
+				<<?php echo $title_elem; ?> class="<?php echo $title_classes; ?>">
+					<?php echo $title; ?>
+				</<?php echo $title_elem; ?>>
+
+				<?php if ( $subtitle ): ?>
+					<<?php echo $subtitle_elem; ?> class="<?php echo $subtitle_classes; ?>">
+						<?php echo $subtitle; ?>
+					</<?php echo $subtitle_elem; ?>>
+				<?php endif; ?>
+			</div>
+		</div>
+	</div>
+</div>
+<?php endif; ?>


### PR DESCRIPTION
**Description**
This set of changes is the first in the adding the header breadcrumb to the Strategic Plan subpages. There will most likely be iterations on the styling classes or styles in general in the near future, but I wanted to get these in for review and in QA for design to feel out.

In this PR we're also adjusting the layout/styles for the 'header_content-title_subtitle' template part, to by default display these headings and subheadings with the stylized text and subtitle that is going to be used on these pages, in order to not use the 'Custom Content' header setting, which would disable the header breadcrumb addition.

**Motivation and Context**
To template-ize the subpages header and breadcrumb so that it appears the same and is styled the same for all subpages. Resolves #3 

Most of this feature implementation was derived from the Coronavirus-Child-Theme.

**How Has This Been Tested?**
Changes viewable in DEV.

**Types of changes**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
